### PR TITLE
Aggiunto schema per richiesta di NotifyDeath

### DIFF
--- a/openapi/inad_api_for_anpr.yaml
+++ b/openapi/inad_api_for_anpr.yaml
@@ -280,20 +280,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              additionalProperties: false
-              description: |-
-                Una notifica di decesso del CITTADINO.
-                Poiché non c'è un metodo GET associato a questo path,
-                conviene inviare le informazioni tramite il payload.
-              required:
-                - codice_fiscale
-                - id_request
-              properties:
-                codice_fiscale:
-                  $ref: '#/components/schemas/Codice_Fiscale'
-                id_request:
-                  $ref: '#/components/schemas/ID_Request'
+              $ref: '#/components/schemas/NotifyDeath'
 
       responses:
         '200':
@@ -406,6 +393,21 @@ components:
           description: Descrizione di dettaglio dello specifico problema verificatosi
           example: <detail_error>
           maxLength: 1024
+    NotifyDeath:
+      type: object
+      additionalProperties: false
+      description: |-
+        Una notifica di decesso del CITTADINO.
+        Poiché non c'è un metodo GET associato a questo path,
+        conviene inviare le informazioni tramite il payload.
+      required:
+        - codice_fiscale
+        - id_request
+      properties:
+        codice_fiscale:
+          $ref: '#/components/schemas/Codice_Fiscale'
+        id_request:
+          $ref: '#/components/schemas/ID_Request'
     NotifyEmail:
       type: object
       additionalProperties: false


### PR DESCRIPTION
Aggiunto nuovo schema per richiesta di uniformare la richiesta dell'oggetto NotifyDeath e non avere due parametri nel request body